### PR TITLE
Add reservable class to reserve link. Closes Redmine 1454.

### DIFF
--- a/ding_periodical.module
+++ b/ding_periodical.module
@@ -147,6 +147,7 @@ function theme_ding_periodical_issues($variables) {
                   'action-button',
                   'reserve-button',
                   'reservable',
+                  'available',
                   'use-ajax',
                 ),
                 'id' => 'reservation-' . $issue_id,


### PR DESCRIPTION
DDBasic doesn't render reserve-button links that doesn't have the .available class as buttons.
